### PR TITLE
Add logging & prevent NPE on ExportDependenciesToTeamcityTask

### DIFF
--- a/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
+++ b/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
@@ -107,10 +107,11 @@ public class ExportDependenciesToTeamcityTask extends DefaultTask {
 
         getLogger().info("ExportDependenciesToTeamcityTask Found dependencies: {}", dependenciesString);
         getLogger().info(
-            "Please note, only dependencies from the following configurations will be registered by release management: {}",
+            "Please note: only {}.* dependencies from {} will be registered by release management",
+            getComponentsRegistryServiceClient().getSupportedGroupIds().stream().findFirst().orElse(""),
             includedConfigurations.stream()
-                    .filter(c -> !excludedConfigurations.contains(c))
-                    .collect(Collectors.toList())
+                .filter(c -> !excludedConfigurations.contains(c))
+                .collect(Collectors.toList())
         );
         System.out.printf("##teamcity[setParameter name='DEPENDENCIES' value='%s']%n", escapedTeamCityValues(dependenciesString));
     }

--- a/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
+++ b/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
@@ -106,11 +106,11 @@ public class ExportDependenciesToTeamcityTask extends DefaultTask {
         }
 
         getLogger().info("ExportDependenciesToTeamcityTask Found dependencies: {}", dependenciesString);
-        getLogger().warn(
-            "If some dependencies are not detected, ensure all dependencies are declared under supported configurations: {}",
+        getLogger().info(
+            "Please ensure all runtime dependencies are declared under supported configurations: {}",
             includedConfigurations.stream()
-                .filter(c -> !excludedConfigurations.contains(c))
-                .collect(Collectors.toList())
+                    .filter(c -> !excludedConfigurations.contains(c))
+                    .collect(Collectors.toList())
         );
         System.out.printf("##teamcity[setParameter name='DEPENDENCIES' value='%s']%n", escapedTeamCityValues(dependenciesString));
     }

--- a/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
+++ b/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
@@ -107,7 +107,7 @@ public class ExportDependenciesToTeamcityTask extends DefaultTask {
 
         getLogger().info("ExportDependenciesToTeamcityTask Found dependencies: {}", dependenciesString);
         getLogger().info(
-            "Please ensure all runtime dependencies are declared under supported configurations: {}",
+            "Please note, only dependencies from the following configurations will be registered by release management: {}",
             includedConfigurations.stream()
                     .filter(c -> !excludedConfigurations.contains(c))
                     .collect(Collectors.toList())

--- a/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
+++ b/src/main/java/org/octopusden/release/management/plugins/gradle/tasks/ExportDependenciesToTeamcityTask.java
@@ -106,13 +106,19 @@ public class ExportDependenciesToTeamcityTask extends DefaultTask {
         }
 
         getLogger().info("ExportDependenciesToTeamcityTask Found dependencies: {}", dependenciesString);
+        getLogger().warn(
+            "If some dependencies are not detected, ensure all dependencies are declared under supported configurations: {}",
+            includedConfigurations.stream()
+                .filter(c -> !excludedConfigurations.contains(c))
+                .collect(Collectors.toList())
+        );
         System.out.printf("##teamcity[setParameter name='DEPENDENCIES' value='%s']%n", escapedTeamCityValues(dependenciesString));
     }
 
     private void assertValidFormat(List<VersionedComponent> components) {
         String notValidComponents = components
                 .stream()
-                .filter(c -> !c.getVersion().matches(VERSION_FORMAT_PATTERN))
+                .filter(c -> c.getVersion() == null || !c.getVersion().matches(VERSION_FORMAT_PATTERN))
                 .map(c -> String.format("[ERROR] Version format not valid %s:%s", c.getName(), c.getVersion()))
                 .collect(Collectors.joining("\n"));
 
@@ -198,6 +204,12 @@ public class ExportDependenciesToTeamcityTask extends DefaultTask {
 
     private Collection<ComponentArtifact> extractConfigurationDependencies(Configuration configuration, Collection<Predicate<ModuleComponentIdentifier>> filters) {
         getLogger().info("Extract Configuration Dependencies for '{}'", configuration.getName());
+
+        configuration.getAllDependencies().forEach(dependency -> {
+            if (dependency.getVersion() == null) {
+                getLogger().warn("Dependency {}:{} has no version declared, this may lead to conflicts with dependency constraints or unexpected resolution behavior", dependency.getGroup(), dependency.getName());
+            }
+        });
 
         final Configuration copiedConfiguration = configuration.copyRecursive();
         copiedConfiguration.setCanBeConsumed(true);


### PR DESCRIPTION
- Prevent `NullPointerException` when a component version is not declared (should throw exception).
- Add logging for the following scenarios:
  - Dependencies declared without a version: May lead to conflicts with dependency constraints or unexpected resolution behavior.
  - Dependencies declared outside supported configurations.