### PR TITLE
OCTOPUS-1599 Rollback the version of confluence-publisher.

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -51,7 +51,7 @@ tasks.register('publishToWiki', DockerTask) {
             throw new IllegalArgumentException("`artifactoryUrl` property must be defined. Example: -PartifactoryUrl=https://artifactory.your-company.com")
         }
     }
-    image = "${project."docker.registry"}/confluencepublisher/confluence-publisher:0.22.0"
+    image = "${project."docker.registry"}/confluencepublisher/confluence-publisher:0.14.0"
     dockerOptions = ['--network', 'host']
     bindMounts = ["${file('src/docs/asciidoc')}:/var/asciidoc-root-folder"]
     env = ["ROOT_CONFLUENCE_URL"    : project.findProperty("WIKI_URL"),


### PR DESCRIPTION
It should be considered a temporary workaround, since version 0.22.0 with the current settings does not work on RHEL9 with Podman.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved reliability of publishing documentation to the wiki by updating the container environment used during the publish step, ensuring more consistent deployments.

* **Chores**
  * Aligned the documentation publishing pipeline with a stable container image to reduce variability and improve compatibility across environments.

* **Notes**
  * No user-facing changes; this affects only the documentation deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->