### PR TITLE
ci: move octopus-base to v2.7.0 (no quality-gates — repository is deprecated)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus-release-management/org.octopusden.octopus-release-management/_VER_/org.octopusden.octopus-release-management-_VER_.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '11'


### PR DESCRIPTION
## What

Three `octopus-base` workflow refs move **v2.1.7 → v2.7.0**. Nothing else.

## What this PR deliberately does NOT do

It was opened as a quality-gates adoption. That is dropped, not deferred: this repository is **deprecated in the organisation and will not be developed further**, so the only thing worth keeping current is the shared release pipeline.

Concretely: no `octopus-quality` plugin (this repository never applied one), no publication policy, no `publish-to-nexus` change. It keeps publishing exactly what it publishes today.

## Why adopting quality-gates here would not have worked anyway

`octopus-quality-plugin` declares `org.gradle.jvm.version = 11` in its Gradle module metadata — checked on Central for **2.4.1, 2.5.2, 2.6.2 and 2.7.0 alike**, so this is not a v2.7.0 regression and not something a downgrade avoids. This repository's TeamCity build configuration runs Gradle on **Java 8** (`JAVA_HOME = %env.JDK_1_8_x64%`), so dependency resolution fails before compilation.

The obvious suspects are not the cause — `detekt-gradle-plugin` 1.23.8 and `ktlint-cli` 1.5.0 both declare `jvm.version = 8`. The requirement comes from the plugin being adopted, which is why it cannot be dropped or swapped at repository level.

## Checks done rather than assumed

- **Input compatibility across a five-minor jump**: `common-java-gradle-release.yml` requires the same inputs at v2.7.0 as at v2.1.7 — `flow-type` and `java-version`, both already supplied. v2.7.0 only adds optional inputs.
- **The release-time size guard** that arrives with v2.6.0+ was checked against what this repository actually publishes: the largest file in 2.0.43 is a **340 KB** javadoc jar, far under the 8 MB default. No `fat-jar-publication-allowlist` entry is needed.
- **The `-Pnexus` conditional publications** — this build declares two extra coordinates when `-Pnexus` is absent (4 publications locally, 2 on the release path). Those legacy coordinates are confirmed **absent from Central**, and since no publication policy is added here, nothing in this change interacts with them. Worth knowing that a future adoption would have to deal with it: a guard wired to `publishToMavenLocal` would fail every ordinary local build.

## Not staged on purpose

`gradlew.bat` shows a whole-file CRLF diff on any checkout in this repository — `core.autocrlf=input` against its `.gitattributes` (`*.bat text eol=crlf`). Unrelated to this change, so only the three workflow files are staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, validation, registration, and release workflows to the latest shared workflow version.
  * Improved consistency and reliability across CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->